### PR TITLE
fix: dont force flags for foreign users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.9)
 
 project(strong_type)
 
-set(CMAKE_CXX_STANDARD 17)
-
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpadded -O3")
-
 set(STRONG_TYPE_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/include/st/is_strong_type.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/st/unwrap.hpp
@@ -22,6 +18,8 @@ target_include_directories(strong_type INTERFACE include)
 option(STRONG_TYPE_BUILD_TESTS "Build tests of the strong_type library" OFF)
 
 if (STRONG_TYPE_BUILD_TESTS)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpadded -O3")
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup()
 


### PR DESCRIPTION
set flags only when building tests